### PR TITLE
[IMP] sale_order_line_sequence: show line number in portal

### DIFF
--- a/sale_order_line_sequence/__manifest__.py
+++ b/sale_order_line_sequence/__manifest__.py
@@ -13,6 +13,7 @@
     "data": [
         "views/sale_view.xml",
         "views/report_saleorder.xml",
+        "views/sale_portal_templates.xml",
         "views/account_move_view.xml",
         "views/report_invoice.xml",
     ],

--- a/sale_order_line_sequence/views/sale_portal_templates.xml
+++ b/sale_order_line_sequence/views/sale_portal_templates.xml
@@ -1,0 +1,24 @@
+<odoo>
+    <template
+        id="sale_order_portal_content_sequence"
+        inherit_id="sale.sale_order_portal_content"
+    >
+        <xpath
+            expr="//table[@id='sales_order_table']/thead/tr/th[@id='product_name_header']"
+            position="before"
+        >
+            <th class="text-start" id="line_number_header">
+                Line Number
+            </th>
+        </xpath>
+
+        <xpath
+            expr="//table[@id='sales_order_table']//t[@name='product_line_row']/td[@id='product_name']"
+            position="before"
+        >
+            <td class="text-start" id="line_number">
+                <span t-field="line.visible_sequence" />
+            </td>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Display the sale order line visible sequence in the portal sales order preview, so the portal view is aligned with the backend form and the sale order PDF report.

Task: 5426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added line numbers to the sale order details view in the customer portal for improved order reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->